### PR TITLE
新增回归测试：图表 X 列校验、文本筛选字面匹配与编码缓存

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,99 @@
+import builtins
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+import pytest
+
+
+matplotlib.use("Agg")
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name: str, relative_path: str):
+    module_path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+visulite_pkg = types.ModuleType("visulite")
+visulite_models_pkg = types.ModuleType("visulite.models")
+visulite_services_pkg = types.ModuleType("visulite.services")
+
+sys.modules["visulite"] = visulite_pkg
+sys.modules["visulite.models"] = visulite_models_pkg
+sys.modules["visulite.services"] = visulite_services_pkg
+
+chart_config = _load_module(
+    "visulite.models.chart_config", "visulite/models/chart_config.py"
+)
+app_state = _load_module("visulite.models.app_state", "visulite/models/app_state.py")
+chart_manager = _load_module(
+    "visulite.services.chart_manager", "visulite/services/chart_manager.py"
+)
+data_loader = _load_module(
+    "visulite.services.data_loader", "visulite/services/data_loader.py"
+)
+data_processor = _load_module(
+    "visulite.services.data_processor", "visulite/services/data_processor.py"
+)
+
+ChartConfig = chart_config.ChartConfig
+ChartManager = chart_manager.ChartManager
+DataLoader = data_loader.DataLoader
+DataProcessor = data_processor.DataProcessor
+FilterCriteria = data_processor.FilterCriteria
+
+
+def test_histogram_does_not_require_x_column():
+    frame = pd.DataFrame({"values": [1, 2, 3, 4, 5]})
+    config = ChartConfig(
+        x_column=None,
+        y_columns=["values"],
+        chart_type="histogram",
+    )
+    manager = ChartManager()
+    fig = matplotlib.figure.Figure()
+    ax = fig.add_subplot(111)
+
+    manager.plot(ax, frame, config)
+
+
+def test_text_filter_uses_literal_match():
+    frame = pd.DataFrame({"text": ["foo.*bar", "foo123bar", "baz"]})
+    criteria = FilterCriteria(text_filters={"text": "foo.*bar"})
+    processor = DataProcessor()
+
+    filtered = processor.apply_filters(frame, criteria)
+
+    assert filtered["text"].tolist() == ["foo.*bar"]
+
+
+def test_encoding_detection_cache_hits(tmp_path, monkeypatch):
+    data_file = tmp_path / "sample.csv"
+    data_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    loader = DataLoader()
+    open_calls = []
+    original_open = builtins.open
+
+    def counting_open(*args, **kwargs):
+        open_calls.append(args[0])
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+
+    first = loader._detect_encoding(data_file)
+    second = loader._detect_encoding(data_file)
+
+    assert first == "utf-8"
+    assert second == "utf-8"
+    assert len(open_calls) == 1

--- a/visulite/services/chart_manager.py
+++ b/visulite/services/chart_manager.py
@@ -33,10 +33,10 @@ class ChartManager:
     ) -> None:
         if config.chart_type not in self.SUPPORTED_TYPES:
             raise ValueError(f"Unsupported chart type {config.chart_type}")
-        if not config.x_column:
-            raise ValueError("X column not selected")
         if not config.y_columns:
             raise ValueError("At least one Y column is required")
+        if config.chart_type in {"line", "bar", "scatter"} and not config.x_column:
+            raise ValueError("X column not selected")
 
         logger.info("Rendering chart type=%s with theme=%s", config.chart_type, theme)
         

--- a/visulite/services/data_loader.py
+++ b/visulite/services/data_loader.py
@@ -24,13 +24,26 @@ class DataLoader:
     # Common encodings to try in order
     ENCODINGS: List[str] = ["utf-8", "utf-8-sig", "gbk", "gb2312", "utf-16", "latin-1"]
 
+    def __init__(self) -> None:
+        self._encoding_cache: dict[Path, tuple[float, str]] = {}
+
     def _detect_encoding(self, file_path: Path) -> str:
         """Try multiple encodings and return the first one that works."""
+        try:
+            stat = file_path.stat()
+        except OSError:
+            stat = None
+        if stat is not None:
+            cached = self._encoding_cache.get(file_path)
+            if cached and cached[0] == stat.st_mtime:
+                return cached[1]
         for encoding in self.ENCODINGS:
             try:
                 with open(file_path, "r", encoding=encoding) as f:
                     f.read(8192)  # Read first 8KB to test
                 logger.info("Detected encoding: %s", encoding)
+                if stat is not None:
+                    self._encoding_cache[file_path] = (stat.st_mtime, encoding)
                 return encoding
             except (UnicodeDecodeError, UnicodeError):
                 continue

--- a/visulite/services/data_processor.py
+++ b/visulite/services/data_processor.py
@@ -27,7 +27,9 @@ class DataProcessor:
         if criteria.text_filters:
             for column, keyword in criteria.text_filters.items():
                 if column in result.columns and keyword:
-                    mask = result[column].astype(str).str.contains(keyword, case=False, na=False)
+                    mask = result[column].astype(str).str.contains(
+                        keyword, case=False, na=False, regex=False
+                    )
                     result = result[mask]
 
         if criteria.numeric_ranges:


### PR DESCRIPTION
### Motivation
- 修正之前对非 XY 图（如 `histogram`/`boxplot`/`heatmap`）错误地强制要求 `x_column` 的校验行为以支持这些图表类型。 
- 避免 `apply_filters` 中将用户输入当作正则表达式解析造成意外匹配或异常，改为使用字面量匹配。 
- 减少对大文件重复探测编码的 I/O 开销，通过缓存检测结果提升加载性能。

### Description
- 在 `visulite/services/chart_manager.py` 中调整校验逻辑，只有当 `chart_type` 为 `line`、`bar` 或 `scatter` 时才强制要求 `x_column`，以允许非 XY 图不指定 X 列。 
- 在 `visulite/services/data_processor.py` 中将 `str.contains` 调用改为 `regex=False` 以使用字面量匹配，修复文本筛选对含有正则元字符文本的误匹配问题。 
- 在 `visulite/services/data_loader.py` 中为 `DataLoader` 增加 `__init__` 初始化 `_encoding_cache`，并在 `_detect_encoding` 中使用 `file_path.stat().st_mtime` 做缓存命中判断，检测成功时写入缓存并在 `stat` 出错时稳健回退。 
- 新增回归测试文件 `tests/test_regressions.py`，测试覆盖：非 XY 图无需 X 列、文本筛选字面量匹配、编码检测缓存命中；测试中通过动态模块加载隔离 GUI 依赖以避免 `PySide6` 导入导致的环境问题。 

### Testing
- 运行 `python -m pytest`，新增测试 `tests/test_regressions.py` 被收集并运行。 
- 测试结果：3 个测试全部通过（`3 passed`），运行时间约 0.9s。 
- 测试包括：`test_histogram_does_not_require_x_column`、`test_text_filter_uses_literal_match`、`test_encoding_detection_cache_hits`，均通过验证预期行为。 
- 在测试中使用了 `matplotlib.use("Agg")` 以及将模块以独立名称加载到 `sys.modules` 来避免 GUI 库导入失败影响测试收集。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972e75073c083328923ef3df6b9b1c2)